### PR TITLE
fix gitter link to link to memstate, not origodb.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,4 @@ layout: layout
 
 * [Community support forum and general discussion list](https://groups.google.com/forum/#!forum/origodb)
 * [Commercial support](/order) - training, workshops and consulting services, on site or remote.
-* [Chat with the team on gitter](https://gitter.im/devrexlabs/origodb)
+* [Chat with the team on gitter](https://gitter.im/memstate)


### PR DESCRIPTION
The link on the memstate docs homepage `https://memstate.io/docs/` links to the wrong gitter. Currently links to origodb, instead of memstate.